### PR TITLE
Overflow scrolling for tabs

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -11,18 +11,25 @@
   height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
   background-image: -webkit-linear-gradient(top, @tab-bar-background-color, lighten(@tab-bar-background-color, 9%));
   box-shadow: inset 0 -8px 8px -4px rgba(0,0,0, .15);
-  padding: 0 10px;
+  padding: 0 10px 0 25px;
+  overflow-x: auto;
+  overflow-y: hidden;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   &:after {
     content: "";
-    position: absolute;
-    bottom: 0;
+    position: fixed;
+    top: @tab-height + @tab-bottom-border-height + 1px; // + 1px border width
     height: @tab-bottom-border-height;
-    left: 0px;
-    width: 100%;
+    left: 0;
+    right: 0;
     background-color: @tab-background-color-active;
     border-bottom: 1px solid @tab-bar-border-color;
     border-top: 1px solid @tab-border-color;
+    pointer-events: none;
   }
 
   .tab {
@@ -97,10 +104,6 @@
       z-index: 1;
       padding-right: 10px
     }
-
-    &:first-child {
-      margin-left: 20px;
-    }
   }
 
   .tab.active {
@@ -133,8 +136,10 @@
 
   .placeholder {
     height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
+    margin-left: -9px; // center between tabs
+    pointer-events: none;
     &:after {
-      top: @tab-height + @tab-top-padding + @tab-bottom-border-height;
+      top: @tab-height + @tab-top-padding + @tab-bottom-border-height - 2px;
     }
   }
 }


### PR DESCRIPTION
Adds support for horizontal scrolling if there are many tabs open. Issue https://github.com/atom/tabs/issues/67

There is a strange edge-case. If you drag one of the last few tabs to the far right and wait until the tooltip appears, somehow it pushes the whole body to the side. The "One" themes are not affected because it only happens if the tabs have `margin` and the skewed pseudo elements. Not sure where or how to fix it. It still works, but it's just kinda ugly. Show stopper?

![tooltip](https://cloud.githubusercontent.com/assets/378023/5046191/8999ab1c-6c4a-11e4-9309-5bb6514b250a.gif)
