### PR TITLE
Style selected items in the tree view according to their git-status

### DIFF
--- a/stylesheets/lists.less
+++ b/stylesheets/lists.less
@@ -26,6 +26,11 @@
     li.list-nested-item.status-@{status} > .list-item {
       color: @color;
     }
+
+    li:not(.list-nested-item).selected.status-@{status},
+    li.list-nested-item.selected.status-@{status} > .list-item {
+      color: @color;
+    }
   }
   .generate-list-item-status-color(@text-color-subtle, ignored);
   .generate-list-item-status-color(@text-color-added, added);


### PR DESCRIPTION
This relates to https://github.com/atom/atom-dark-ui/pull/34

I must admit that it looks way better on the dark theme though.
The missing contrast between the orange text color and the light background makes it hard to read.

Any ideas? Maybe make the selection background darker!?
