### PR TITLE
Make tab bottom border positioned relative to bottom

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -21,8 +21,8 @@
 
   &:after {
     content: "";
-    position: fixed;
-    top: @tab-height + @tab-bottom-border-height + 1px; // + 1px border width
+    position: absolute;
+    bottom: 0;
     height: @tab-bottom-border-height;
     left: 0;
     right: 0;


### PR DESCRIPTION
Both this theme and the dark theme have the tab bar's underline positioned assuming the tab bar is the only thing in the top section.  Anything added using atom.workspaceView.prependToTop will cause layout issues: 

![screen shot 2014-12-22 at 11 23 02 pm](https://cloud.githubusercontent.com/assets/343042/5534656/7ee06afa-8a34-11e4-80c4-b3b8f2dd9ac2.png)

