### PR TITLE
Show tree-view diff colors when selected

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -29,7 +29,7 @@
 
     li:not(.list-nested-item).selected.status-@{status},
     li.list-nested-item.selected.status-@{status} > .list-item {
-      color: darken(@color, 15%);
+      color: lighten(@color, 30%);
     }
   }
   .generate-list-item-status-color(@text-color-subtle, ignored);

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -29,7 +29,7 @@
 
     li:not(.list-nested-item).selected.status-@{status},
     li.list-nested-item.selected.status-@{status} > .list-item {
-      color: darken(@color, 15%);
+      color: darken(@color, 7%);
     }
   }
   .generate-list-item-status-color(@text-color-subtle, ignored);

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -29,7 +29,7 @@
 
     li:not(.list-nested-item).selected.status-@{status},
     li.list-nested-item.selected.status-@{status} > .list-item {
-      color: lighten(@color, 30%);
+      color: darken(@color, 15%);
     }
   }
   .generate-list-item-status-color(@text-color-subtle, ignored);

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -27,13 +27,5 @@
 		.selected:before {
 			background: @background-color-selected;
 		}
-
-		.selected > .name,
-		.selected > .name:before,
-		.selected > .list-item.header:before,
-		.selected > .list-item > .name,
-		.selected > .list-item > .name:before {
-			color: #fff !important;
-		}
 	}
 }

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -7,7 +7,7 @@
 
 @text-color-info: #5293d8;
 @text-color-success: #529b2f;
-@text-color-warning: #ff982d;
+@text-color-warning: #C46300;
 @text-color-error: #c00;
 
 @text-color-ignored: @text-color-subtle;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -6,8 +6,8 @@
 @text-color-selected: #fff;
 
 @text-color-info: #5293d8;
-@text-color-success: #529b2f;
-@text-color-warning: #C46300;
+@text-color-success: #45A815;
+@text-color-warning: #CD8E00;
 @text-color-error: #c00;
 
 @text-color-ignored: @text-color-subtle;


### PR DESCRIPTION
This PR keeps showing the git diff colors also when selecting in the tree-view.

Before: 

![screen shot 2015-03-13 at 4 07 11 pm](https://cloud.githubusercontent.com/assets/378023/6649003/d737bbfa-c99e-11e4-9db0-7d8c4410590e.png)


After: 

![screen shot 2015-03-13 at 5 54 52 pm](https://cloud.githubusercontent.com/assets/378023/6649575/2560048a-c9aa-11e4-945d-36a8d82c0346.png)


Readability suffers, but since the blue background is only shown when focusing, I think it's still ok.