### PR TITLE
Hide tooltips behind panels

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -4,3 +4,7 @@ atom-workspace {
   background-color: @app-background-color;
   border-top: 1px solid rgba(0, 0, 0, .4);
 }
+
+atom-panel-container {
+  z-index: 5;
+}


### PR DESCRIPTION
Before 
<img width="726" alt="screen shot 2016-03-18 at 11 23 01 am" src="https://cloud.githubusercontent.com/assets/4278113/13887958/e561b79a-ecfb-11e5-9bd4-0fa0740479d8.png">

After
<img width="733" alt="screen shot 2016-03-18 at 11 22 32 am" src="https://cloud.githubusercontent.com/assets/4278113/13887965/f1746780-ecfb-11e5-9bb3-e72dfe470f9e.png">

Fixes https://github.com/AtomLinter/linter-ui-default/issues/51
Related https://github.com/atom/one-dark-ui/pull/127
Related https://github.com/atom/one-light-ui/pull/54