### PR TITLE
Restore missing border for status bar

### DIFF
--- a/styles/panels.less
+++ b/styles/panels.less
@@ -15,7 +15,8 @@ atom-panel, .tool-panel {
 
   background-color: @tool-panel-background-color;
 
-  &.bottom, &.panel-bottom {
+  &.bottom, &.panel-bottom,
+  &.footer, &.footer-bottom {
     border-top: 1px solid @tool-panel-border-color;
   }
 


### PR DESCRIPTION
Atom v1.8.0 relocated the status bar to the footer panel instead of the bottom panel. The result was this:

<img src="https://cloud.githubusercontent.com/assets/2346707/15847779/fcfa5b36-2ccb-11e6-983d-f656e77d0cf3.png" width="745" alt="Figure 1" />

I've patched it so it restores the border to panels in the footer-panel as well as the bottom-panel:

<img src="https://cloud.githubusercontent.com/assets/2346707/15847811/383eb78c-2ccc-11e6-83f6-1dca77d3aced.png" width="745" alt="Figure 2" />