### PR TITLE
Remove top border

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -2,5 +2,4 @@
 
 atom-workspace {
   background-color: @app-background-color;
-  border-top: 1px solid rgba(0, 0, 0, .4);
 }


### PR DESCRIPTION
Before | After
--- | ---
![screen shot 2016-06-08 at 4 04 52 pm](https://cloud.githubusercontent.com/assets/378023/15885599/31c2520c-2d93-11e6-9f8c-fe96b95cf439.png) | ![screen shot 2016-06-08 at 4 05 16 pm](https://cloud.githubusercontent.com/assets/378023/15885603/3684df80-2d93-11e6-85d1-b82bbc24eeb9.png)

In the past, I think the title-bar didn't have a border, but it later got added. So we can now remove it in this theme so there is no double border.