### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -5,17 +5,17 @@ atom-workspace {
 }
 
 .scrollbars-visible-always {
-  /deep/ ::-webkit-scrollbar {
+  ::-webkit-scrollbar {
     width: 10px;
     height: 10px;
   }
 
-  /deep/ ::-webkit-scrollbar-track,
-  /deep/ ::-webkit-scrollbar-corner {
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
     background: @scrollbar-background-color;
   }
 
-  /deep/ ::-webkit-scrollbar-thumb {
+  ::-webkit-scrollbar-thumb {
     background: @scrollbar-color;
     border-radius: 5px;
 		box-shadow: 0 0 1px white inset;

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "ui-mixins";
 
-atom-text-editor[mini], atom-text-editor[mini]::shadow {
+atom-text-editor[mini] {
   color: lighten(@text-color, 15%);
   background-color: darken(@input-background-color, 1%);
   border: 1px solid lighten(@input-border-color, 10%);
@@ -17,7 +17,7 @@ atom-text-editor[mini], atom-text-editor[mini]::shadow {
   }
 }
 
-atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
+atom-text-editor[mini].is-focused {
   color: @text-color;
   background-color: @input-background-color;
   border-color: @input-border-color;
@@ -30,7 +30,7 @@ atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
 }
 
 // FIXME: these should go in syntax themes?
-atom-text-editor, atom-text-editor::shadow {
+atom-text-editor {
   .gutter.drop-shadow {
     -webkit-box-shadow: -2px 0 10px 2px #222;
   }


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai